### PR TITLE
Bump kotlin sdk to 1.3.28

### DIFF
--- a/.github/scripts/run_embedded_e2e_shard.sh
+++ b/.github/scripts/run_embedded_e2e_shard.sh
@@ -85,10 +85,13 @@ run_with_retries() {
       echo "::warning::Patrol attempt $((attempt - 1)) failed; retrying ($attempt/$MAX_RETRIES)..."
       recover_between_retries
     fi
-    set +e
-    run_patrol "${patrol_args[@]}"
-    status=$?
-    set -e
+    # `|| status=$?` keeps errexit from killing the script when run_patrol
+    # returns non-zero. `set +e` alone is unsafe here: run_patrol toggles
+    # errexit internally and leaves it ON before `return 77`, so by the time
+    # control returns to this line errexit is back on and bash exits before
+    # `status=$?` runs — masking flakes as fatal failures and skipping retries.
+    status=0
+    run_patrol "${patrol_args[@]}" || status=$?
     if [[ "$status" -eq 0 ]]; then
       return 0
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.0.46
+Bump frontegg-android-kotlin version to 1.3.28.
+- Trust server tenant on fresh login instead of stale cache.
+- Gate `AndroidDebugConfigurationChecker` on host app debuggable flag.
+
 ## v1.0.45
 Bump frontegg-android-kotlin sdk to 1.3.27.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
 
-    implementation 'com.frontegg.sdk:android:1.3.27'
+    implementation 'com.frontegg.sdk:android:1.3.28'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     implementation 'androidx.core:core-ktx:1.10.0'

--- a/application_id/android/app/build.gradle
+++ b/application_id/android/app/build.gradle
@@ -128,5 +128,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.27'
+    implementation 'com.frontegg.sdk:android:1.3.28'
 }

--- a/embedded/android/app/build.gradle
+++ b/embedded/android/app/build.gradle
@@ -128,5 +128,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.27'
+    implementation 'com.frontegg.sdk:android:1.3.28'
 }

--- a/hosted/android/app/build.gradle
+++ b/hosted/android/app/build.gradle
@@ -124,5 +124,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.27'
+    implementation 'com.frontegg.sdk:android:1.3.28'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: frontegg_flutter
 description: Flutter package for Frontegg services
-version: 1.0.45
+version: 1.0.46
 homepage: https://github.com/frontegg/frontegg-flutter
 #publish_to: "https://pub.dartlang.org"
 


### PR DESCRIPTION
## Summary
- Trust server tenant on fresh login instead of stale cache.
- Gate `AndroidDebugConfigurationChecker` on host app debuggable flag.
