### PR TITLE
FR-24939 - chore(deps): bump native SDKs to Android 1.3.35 / iOS 1.3.11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
 
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     implementation 'androidx.core:core-ktx:1.10.0'

--- a/application_id/android/app/build.gradle
+++ b/application_id/android/app/build.gradle
@@ -128,5 +128,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,9 +34,9 @@ Sign up here → [https://portal.us.frontegg.com/signup](https://portal.us.front
 
 The Flutter SDK supports Frontegg's **per-tenant sessions** feature through the underlying native SDKs.
 
-- On **Android**, the plugin and example apps use `com.frontegg.sdk:android:1.3.34`.
+- On **Android**, the plugin and example apps use `com.frontegg.sdk:android:1.3.35`.
 - On **iOS**, the plugin depends on `FronteggSwift`:
-  - **Flutter 3.41+** (SPM): `1.3.10` from GitHub. Run `flutter config --enable-swift-package-manager`, then `flutter pub get` and build.
+  - **Flutter 3.41+** (SPM): `1.3.11` from GitHub. Run `flutter config --enable-swift-package-manager`, then `flutter pub get` and build.
   - Note: CocoaPods fallback is no longer supported for `FronteggSwift`.
   - SPM integration requires **Xcode 15+**.
 

--- a/embedded/android/app/build.gradle
+++ b/embedded/android/app/build.gradle
@@ -128,5 +128,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
 }

--- a/hosted/android/app/build.gradle
+++ b/hosted/android/app/build.gradle
@@ -124,5 +124,5 @@ flutter {
 
 dependencies {
     androidTestUtil "androidx.test:orchestrator:1.5.1"
-    implementation 'com.frontegg.sdk:android:1.3.34'
+    implementation 'com.frontegg.sdk:android:1.3.35'
 }

--- a/ios/frontegg_flutter/Package.swift
+++ b/ios/frontegg_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.10"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.11"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
- Bump native SDKs: `frontegg-android-kotlin` **1.3.34 → 1.3.35**, `frontegg-ios-swift` (FronteggSwift) **1.3.10 → 1.3.11**.

What this picks up:

- Fixed: embedded step-up renders the MFA challenge instead of a blank page — the embedded login WebView exposes the native `getTokens` token bridge and a new step-up web driver routes the hosted login box to its step-up page, completing with an elevated (stepped-up) token. Requires hosted login box ≥ 7.118.0. (FR-24939)
- Fixed (iOS): step-up authorize URL emits OIDC-compliant integer `max_age`; connectivity observer stays alive across repeated offline/online cycles. (FR-25783)
- Fixed (Android): token refresh no longer stalls on short-TTL environments (refresh dedup keyed on token identity); deprecated `startActivityForResult` removed. (FR-19725)

All version references bumped: plugin + example app Gradle pins, SPM/CocoaPods manifests, and docs.

> Note: `com.frontegg.sdk:android:1.3.35` was released ~40 min ago and may still be syncing to Maven Central — if the Android CI job fails on dependency resolution, re-run it after sync.
