### PR TITLE
feat(entitlements): add feature/permission entitlement query API

### DIFF
--- a/.github/workflows/onPush.yaml
+++ b/.github/workflows/onPush.yaml
@@ -18,6 +18,29 @@ jobs:
           PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REF_NAME" --state open --json number --jq length)
           echo "has_pr=$( [ "$PR_COUNT" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
+  # Lightweight Dart analyze + unit tests. Unlike `build` (below), this is NOT gated on
+  # has_pr, so unit tests run on every push — including PR branches — cheaply on ubuntu
+  # (the expensive app builds stay in `build`, which is skipped when a PR exists).
+  dart-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze code
+        run: flutter analyze lib test
+
+      - name: Run tests
+        run: flutter test
+
   build:
     needs: check-pr
     # Skip when an open PR exists — PR-triggered workflows already cover this branch.

--- a/android/src/main/kotlin/com/frontegg/flutter/FronteggMethodCallHandler.kt
+++ b/android/src/main/kotlin/com/frontegg/flutter/FronteggMethodCallHandler.kt
@@ -6,6 +6,7 @@ import com.frontegg.android.AdminPortalActivity
 import com.frontegg.android.EmbeddedAuthActivity
 import com.frontegg.android.exceptions.FronteggException
 import com.frontegg.android.fronteggAuth
+import com.frontegg.android.models.Entitlement
 import com.frontegg.android.services.StorageProvider
 import com.frontegg.flutter.stateListener.FronteggStateListenerImpl
 import io.flutter.plugin.common.MethodCall
@@ -55,6 +56,8 @@ class FronteggMethodCallHandler(
             "forceStateUpdate" -> forceStateUpdate(result)
 
             "loadEntitlements" -> loadEntitlements(call, result)
+            "getFeatureEntitlement" -> getFeatureEntitlement(call, result)
+            "getPermissionEntitlement" -> getPermissionEntitlement(call, result)
 
             "openAdminPortal" -> openAdminPortal(result)
 
@@ -427,6 +430,36 @@ class FronteggMethodCallHandler(
             result.success(success)
         }
     }
+
+    private fun getFeatureEntitlement(
+        call: MethodCall,
+        result: MethodChannel.Result,
+    ) {
+        val key = call.argument<String>("key")
+        if (key == null) {
+            result.error("MISSING_PARAMS", "Missing feature key", null)
+            return
+        }
+        result.success(entitlementToMap(context.fronteggAuth.getFeatureEntitlements(key)))
+    }
+
+    private fun getPermissionEntitlement(
+        call: MethodCall,
+        result: MethodChannel.Result,
+    ) {
+        val key = call.argument<String>("key")
+        if (key == null) {
+            result.error("MISSING_PARAMS", "Missing permission key", null)
+            return
+        }
+        result.success(entitlementToMap(context.fronteggAuth.getPermissionEntitlements(key)))
+    }
+
+    private fun entitlementToMap(entitlement: Entitlement): Map<String, Any?> =
+        mapOf(
+            "isEntitled" to entitlement.isEntitled,
+            "justification" to entitlement.justification,
+        )
 
     private fun openAdminPortal(result: MethodChannel.Result) {
         val activity = activityProvider.getActivity()

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -130,6 +130,33 @@ final success = await frontegg.loadEntitlements(forceRefresh: true);
 - `forceRefresh: true` — always performs a network request.
 - `forceRefresh: false` — uses the SDK cache when possible.
 
+### Checking a feature or permission entitlement
+
+After entitlements are loaded (automatically on login or via `loadEntitlements`), query
+whether the current user is entitled to a specific feature or permission. The check is
+evaluated on-device against the loaded state and returns an [`Entitlement`]:
+
+```dart
+final frontegg = FronteggFlutter();
+await frontegg.loadEntitlements();
+
+final feature = await frontegg.getFeatureEntitlement('my-feature-key');
+if (feature.isEntitled) {
+  // grant access
+} else {
+  debugPrint('Not entitled: ${feature.justification}'); // e.g. MISSING_FEATURE
+}
+
+final permission = await frontegg.getPermissionEntitlement('my-permission-key');
+```
+
+`Entitlement` exposes:
+
+- `isEntitled` — whether the user is entitled.
+- `justification` — when `isEntitled` is `false`, the reason code (`MISSING_FEATURE`,
+  `MISSING_PERMISSION`, `BUNDLE_EXPIRED`, or the SDK preconditions `NOT_AUTHENTICATED`,
+  `ENTITLEMENTS_DISABLED`, `ENTITLEMENTS_NOT_LOADED`).
+
 ## Android
 
 ### Multi-app support

--- a/ios/frontegg_flutter/Sources/frontegg_flutter/FronteggMethodCallHandler.swift
+++ b/ios/frontegg_flutter/Sources/frontegg_flutter/FronteggMethodCallHandler.swift
@@ -45,6 +45,10 @@ class FronteggMethodCallHandler {
             isSteppedUp(call: call, result: result)
         case "loadEntitlements":
             loadEntitlements(call: call, result: result)
+        case "getFeatureEntitlement":
+            getFeatureEntitlement(call: call, result: result)
+        case "getPermissionEntitlement":
+            getPermissionEntitlement(call: call, result: result)
         case "openAdminPortal":
             openAdminPortal(result: result)
             
@@ -360,6 +364,37 @@ class FronteggMethodCallHandler {
         ) { success in
             result(success)
         }
+    }
+
+    private func getFeatureEntitlement(
+        call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        guard let arguments = call.arguments as? [String: Any?],
+              let key = arguments["key"] as? String
+        else {
+            return result(FlutterError(code: "MISSING_PARAMS", message: "Missing feature key", details: nil))
+        }
+        result(Self.entitlementToDict(fronteggApp.auth.getFeatureEntitlements(featureKey: key)))
+    }
+
+    private func getPermissionEntitlement(
+        call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        guard let arguments = call.arguments as? [String: Any?],
+              let key = arguments["key"] as? String
+        else {
+            return result(FlutterError(code: "MISSING_PARAMS", message: "Missing permission key", details: nil))
+        }
+        result(Self.entitlementToDict(fronteggApp.auth.getPermissionEntitlements(permissionKey: key)))
+    }
+
+    private static func entitlementToDict(_ entitlement: Entitlement) -> [String: Any?] {
+        [
+            "isEntitled": entitlement.isEntitled,
+            "justification": entitlement.justification,
+        ]
     }
 
     private func openAdminPortal(result: @escaping FlutterResult) {

--- a/lib/frontegg_flutter.dart
+++ b/lib/frontegg_flutter.dart
@@ -1,5 +1,6 @@
 export 'src/frontegg_flutter.dart';
 export 'src/frontegg_provider.dart';
+export 'src/models/entitlement.dart';
 export 'src/models/frontegg_constants.dart';
 export 'src/models/frontegg_state.dart';
 export 'src/models/frontegg_tenant.dart';

--- a/lib/src/frontegg_flutter.dart
+++ b/lib/src/frontegg_flutter.dart
@@ -339,6 +339,25 @@ class FronteggFlutter {
         ),
       );
 
+  /// Returns the [Entitlement] for the given feature key.
+  ///
+  /// Evaluated on-device from the state populated by the last successful
+  /// [loadEntitlements] call — call [loadEntitlements] first (returns
+  /// `isEntitled: false, justification: "ENTITLEMENTS_NOT_LOADED"` otherwise).
+  Future<Entitlement> getFeatureEntitlement(String featureKey) => _runAction(
+        () => FronteggPlatform.instance.getFeatureEntitlement(featureKey),
+      );
+
+  /// Returns the [Entitlement] for the given permission key.
+  ///
+  /// Evaluated on-device from the state populated by the last successful
+  /// [loadEntitlements] call — call [loadEntitlements] first (returns
+  /// `isEntitled: false, justification: "ENTITLEMENTS_NOT_LOADED"` otherwise).
+  Future<Entitlement> getPermissionEntitlement(String permissionKey) =>
+      _runAction(
+        () => FronteggPlatform.instance.getPermissionEntitlement(permissionKey),
+      );
+
   /// Opens the embedded Frontegg Admin Portal.
   ///
   /// The portal loads `${baseUrl}/oauth/portal` in a native WebView that shares

--- a/lib/src/frontegg_method_channel.dart
+++ b/lib/src/frontegg_method_channel.dart
@@ -1,5 +1,6 @@
 import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
+import "package:frontegg_flutter/src/models/entitlement.dart";
 
 import "frontegg_platform_interface.dart";
 
@@ -27,6 +28,9 @@ class FronteggMethodChannel extends FronteggPlatform {
   static const String stepUpMethodName = "stepUp";
   static const String isSteppedUpMethodName = "isSteppedUp";
   static const String loadEntitlementsMethodName = "loadEntitlements";
+  static const String getFeatureEntitlementMethodName = "getFeatureEntitlement";
+  static const String getPermissionEntitlementMethodName =
+      "getPermissionEntitlement";
   static const String openAdminPortalMethodName = "openAdminPortal";
 
   /// MethodChannel used for invoking platform-specific methods.
@@ -244,6 +248,26 @@ class FronteggMethodChannel extends FronteggPlatform {
   @override
   Future<void> forceStateUpdate() =>
       methodChannel.invokeMethod<void>("forceStateUpdate");
+
+  @override
+  Future<Entitlement> getFeatureEntitlement(String featureKey) async =>
+      Entitlement.fromMap(
+        (await methodChannel.invokeMethod<Map<Object?, Object?>>(
+              getFeatureEntitlementMethodName,
+              {"key": featureKey},
+            )) ??
+            const {},
+      );
+
+  @override
+  Future<Entitlement> getPermissionEntitlement(String permissionKey) async =>
+      Entitlement.fromMap(
+        (await methodChannel.invokeMethod<Map<Object?, Object?>>(
+              getPermissionEntitlementMethodName,
+              {"key": permissionKey},
+            )) ??
+            const {},
+      );
 
   @override
   Future<bool> loadEntitlements({

--- a/lib/src/frontegg_platform_interface.dart
+++ b/lib/src/frontegg_platform_interface.dart
@@ -1,4 +1,5 @@
 import "package:frontegg_flutter/src/frontegg_method_channel.dart";
+import "package:frontegg_flutter/src/models/entitlement.dart";
 import "package:plugin_platform_interface/plugin_platform_interface.dart";
 
 abstract class FronteggPlatform extends PlatformInterface {
@@ -101,6 +102,18 @@ abstract class FronteggPlatform extends PlatformInterface {
   /// Triggers a manual entitlements load on the native SDKs.
   ///
   /// Returns `true` if entitlements were successfully loaded, otherwise `false`.
+  Future<Entitlement> getFeatureEntitlement(String featureKey) {
+    throw UnimplementedError(
+      "getFeatureEntitlement() has not been implemented.",
+    );
+  }
+
+  Future<Entitlement> getPermissionEntitlement(String permissionKey) {
+    throw UnimplementedError(
+      "getPermissionEntitlement() has not been implemented.",
+    );
+  }
+
   Future<bool> loadEntitlements({
     bool forceRefresh = false,
   }) {

--- a/lib/src/models/entitlement.dart
+++ b/lib/src/models/entitlement.dart
@@ -1,0 +1,44 @@
+/// Result of an entitlement check via
+/// [FronteggFlutter.getFeatureEntitlement] / [FronteggFlutter.getPermissionEntitlement].
+///
+/// Evaluated on-device from the in-memory entitlements state populated by the last
+/// successful [FronteggFlutter.loadEntitlements] call, so a check is cheap and synchronous
+/// on the native side.
+class Entitlement {
+  /// Whether the user is entitled to the requested feature/permission.
+  final bool isEntitled;
+
+  /// When [isEntitled] is `false`, the reason code — one of the canonical values mirrored
+  /// from `@frontegg/entitlements-javascript-commons` (`MISSING_FEATURE`,
+  /// `MISSING_PERMISSION`, `BUNDLE_EXPIRED`) plus the mobile-specific preconditions
+  /// (`NOT_AUTHENTICATED`, `ENTITLEMENTS_DISABLED`, `ENTITLEMENTS_NOT_LOADED`). `null` when
+  /// [isEntitled] is `true`.
+  final String? justification;
+
+  const Entitlement({
+    required this.isEntitled,
+    this.justification,
+  });
+
+  factory Entitlement.fromMap(Map<Object?, Object?> map) {
+    return Entitlement(
+      isEntitled: map["isEntitled"] as bool? ?? false,
+      justification: map["justification"] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Entitlement &&
+          runtimeType == other.runtimeType &&
+          isEntitled == other.isEntitled &&
+          justification == other.justification;
+
+  @override
+  int get hashCode => isEntitled.hashCode ^ justification.hashCode;
+
+  @override
+  String toString() =>
+      "Entitlement(isEntitled: $isEntitled, justification: $justification)";
+}

--- a/test/src/frontegg_flutter_test.custom_mocks.dart
+++ b/test/src/frontegg_flutter_test.custom_mocks.dart
@@ -6,6 +6,7 @@
 import 'dart:async' as _i3;
 
 import 'package:frontegg_flutter/src/frontegg_platform_interface.dart' as _i2;
+import 'package:frontegg_flutter/src/models/entitlement.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart'
     as _i3;
@@ -143,6 +144,30 @@ class MockFronteggPlatform extends _i1.Mock
         ),
         returnValue: _i3.Future<Map<Object?, Object?>?>.value(),
       ) as _i3.Future<Map<Object?, Object?>?>);
+
+  @override
+  _i3.Future<_i4.Entitlement> getFeatureEntitlement(String? featureKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getFeatureEntitlement,
+          [featureKey],
+        ),
+        returnValue: _i3.Future<_i4.Entitlement>.value(
+          const _i4.Entitlement(isEntitled: false),
+        ),
+      ) as _i3.Future<_i4.Entitlement>);
+
+  @override
+  _i3.Future<_i4.Entitlement> getPermissionEntitlement(String? permissionKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPermissionEntitlement,
+          [permissionKey],
+        ),
+        returnValue: _i3.Future<_i4.Entitlement>.value(
+          const _i4.Entitlement(isEntitled: false),
+        ),
+      ) as _i3.Future<_i4.Entitlement>);
 
   @override
   _i3.Future<Map<String, Object>?> requestAuthorize({

--- a/test/src/frontegg_flutter_test.dart
+++ b/test/src/frontegg_flutter_test.dart
@@ -350,6 +350,37 @@ void main() {
     });
   });
 
+  group('getFeatureEntitlement()', () {
+    test('should call FronteggPlatform.instance.getFeatureEntitlement()',
+        () async {
+      // Arrange
+      const expected = Entitlement(isEntitled: true);
+      when(fronteggPlatform.getFeatureEntitlement('my-feature'))
+          .thenAnswer((_) async => expected);
+      // Act
+      final result = await frontegg.getFeatureEntitlement('my-feature');
+      // Assert
+      expect(result, expected);
+      verify(fronteggPlatform.getFeatureEntitlement('my-feature')).called(1);
+    });
+  });
+
+  group('getPermissionEntitlement()', () {
+    test('should call FronteggPlatform.instance.getPermissionEntitlement()',
+        () async {
+      // Arrange
+      const expected =
+          Entitlement(isEntitled: false, justification: 'MISSING_PERMISSION');
+      when(fronteggPlatform.getPermissionEntitlement('my-perm'))
+          .thenAnswer((_) async => expected);
+      // Act
+      final result = await frontegg.getPermissionEntitlement('my-perm');
+      // Assert
+      expect(result, expected);
+      verify(fronteggPlatform.getPermissionEntitlement('my-perm')).called(1);
+    });
+  });
+
   group('stepUp()', () {
     test('should call FronteggPlatform.instance.stepUp()', () async {
       // Arrange

--- a/test/src/frontegg_method_channel_test.dart
+++ b/test/src/frontegg_method_channel_test.dart
@@ -62,6 +62,10 @@ void main() {
             return null;
           case FronteggMethodChannel.stepUpMethodName:
             return null;
+          case FronteggMethodChannel.getFeatureEntitlementMethodName:
+            return {"isEntitled": true, "justification": null};
+          case FronteggMethodChannel.getPermissionEntitlementMethodName:
+            return {"isEntitled": false, "justification": "MISSING_PERMISSION"};
           case FronteggMethodChannel.openAdminPortalMethodName:
             return null;
         }
@@ -127,6 +131,18 @@ void main() {
 
   test('isSteppedUp()', () async {
     await platform.isSteppedUp();
+  });
+
+  test('getFeatureEntitlement() parses the channel result', () async {
+    final result = await platform.getFeatureEntitlement('my-feature');
+    expect(result.isEntitled, isTrue);
+    expect(result.justification, isNull);
+  });
+
+  test('getPermissionEntitlement() parses the channel result', () async {
+    final result = await platform.getPermissionEntitlement('my-perm');
+    expect(result.isEntitled, isFalse);
+    expect(result.justification, 'MISSING_PERMISSION');
   });
 
   test('stepUP()', () async {

--- a/test/src/frontegg_provider_test.mocks.dart
+++ b/test/src/frontegg_provider_test.mocks.dart
@@ -42,6 +42,16 @@ class _FakeFronteggConstants_1 extends _i1.SmartFake
         );
 }
 
+class _FakeEntitlement_2 extends _i1.SmartFake implements _i2.Entitlement {
+  _FakeEntitlement_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [FronteggFlutter].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -140,6 +150,66 @@ class MockFronteggFlutter extends _i1.Mock implements _i2.FronteggFlutter {
       ) as _i3.Future<void>);
 
   @override
+  _i3.Future<void> directLogin({
+    required String? url,
+    bool? ephemeralSession = true,
+    Map<String, String>? additionalQueryParams,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #directLogin,
+          [],
+          {
+            #url: url,
+            #ephemeralSession: ephemeralSession,
+            #additionalQueryParams: additionalQueryParams,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> socialLogin({
+    required _i2.FronteggSocialProvider? provider,
+    bool? ephemeralSession = true,
+    Map<String, String>? additionalQueryParams,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #socialLogin,
+          [],
+          {
+            #provider: provider,
+            #ephemeralSession: ephemeralSession,
+            #additionalQueryParams: additionalQueryParams,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> customSocialLogin({
+    required String? id,
+    bool? ephemeralSession = true,
+    Map<String, String>? additionalQueryParams,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #customSocialLogin,
+          [],
+          {
+            #id: id,
+            #ephemeralSession: ephemeralSession,
+            #additionalQueryParams: additionalQueryParams,
+          },
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<bool> refreshToken() => (super.noSuchMethod(
         Invocation.method(
           #refreshToken,
@@ -175,6 +245,16 @@ class MockFronteggFlutter extends _i1.Mock implements _i2.FronteggFlutter {
       ) as _i3.Future<_i2.FronteggConstants>);
 
   @override
+  _i3.Future<void> forceStateUpdate() => (super.noSuchMethod(
+        Invocation.method(
+          #forceStateUpdate,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
   _i3.Future<_i2.FronteggUser?> requestAuthorize({
     required String? refreshToken,
     String? deviceTokenCookie,
@@ -190,4 +270,78 @@ class MockFronteggFlutter extends _i1.Mock implements _i2.FronteggFlutter {
         ),
         returnValue: _i3.Future<_i2.FronteggUser?>.value(),
       ) as _i3.Future<_i2.FronteggUser?>);
+
+  @override
+  _i3.Future<bool> isSteppedUp({Duration? maxAge}) => (super.noSuchMethod(
+        Invocation.method(
+          #isSteppedUp,
+          [],
+          {#maxAge: maxAge},
+        ),
+        returnValue: _i3.Future<bool>.value(false),
+      ) as _i3.Future<bool>);
+
+  @override
+  _i3.Future<void> stepUp({Duration? maxAge}) => (super.noSuchMethod(
+        Invocation.method(
+          #stepUp,
+          [],
+          {#maxAge: maxAge},
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<bool> loadEntitlements({bool? forceRefresh = false}) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadEntitlements,
+          [],
+          {#forceRefresh: forceRefresh},
+        ),
+        returnValue: _i3.Future<bool>.value(false),
+      ) as _i3.Future<bool>);
+
+  @override
+  _i3.Future<_i2.Entitlement> getFeatureEntitlement(String? featureKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getFeatureEntitlement,
+          [featureKey],
+        ),
+        returnValue: _i3.Future<_i2.Entitlement>.value(_FakeEntitlement_2(
+          this,
+          Invocation.method(
+            #getFeatureEntitlement,
+            [featureKey],
+          ),
+        )),
+      ) as _i3.Future<_i2.Entitlement>);
+
+  @override
+  _i3.Future<_i2.Entitlement> getPermissionEntitlement(String? permissionKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPermissionEntitlement,
+          [permissionKey],
+        ),
+        returnValue: _i3.Future<_i2.Entitlement>.value(_FakeEntitlement_2(
+          this,
+          Invocation.method(
+            #getPermissionEntitlement,
+            [permissionKey],
+          ),
+        )),
+      ) as _i3.Future<_i2.Entitlement>);
+
+  @override
+  _i3.Future<void> openAdminPortal() => (super.noSuchMethod(
+        Invocation.method(
+          #openAdminPortal,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 }


### PR DESCRIPTION
- Added: `getFeatureEntitlement(featureKey)` and `getPermissionEntitlement(permissionKey)` — query whether the current user is entitled to a specific feature/permission from Dart, returning an `Entitlement { isEntitled, justification }`. Previously only `loadEntitlements()` (a load trigger) was exposed, so apps had to decode JWT claims by hand.

Bridged to the native `getFeatureEntitlements`/`getPermissionEntitlements` on both platforms (evaluated on-device from the state populated by `loadEntitlements`). New Dart `Entitlement` model + barrel export; Android + iOS method-call handlers; unit tests (delegation + method-channel parsing); `docs/advanced.md` examples.

Closes a wrapper parity gap vs. React Native / native SDKs, where the feature/permission query already exists.