### PR TITLE
chore(deps): bump native SDKs to Android 1.3.36 / iOS 1.3.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.mockito:mockito-core:5.0.0'
 
-    implementation 'com.frontegg.sdk:android:1.3.35'
+    implementation 'com.frontegg.sdk:android:1.3.36'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
     implementation 'androidx.core:core-ktx:1.10.0'

--- a/ios/frontegg_flutter/Package.swift
+++ b/ios/frontegg_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.11"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.12"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bumps the bundled native SDK versions so the Flutter wrapper picks up the July 2026 mobile-SDK audit fixes:

- **Android** `com.frontegg.sdk:android` 1.3.35 → **1.3.36** (blocking-network-on-main-thread crash, RFC-7636 PKCE verifier length, process-death login callback, webview-bridge same-origin gate + log hygiene)
- **iOS** FronteggSwift (SPM) 1.3.11 → **1.3.12** (root-VC host-app termination, per-tenant refresh deadlock, concurrent-refresh spurious logout, passkey login + registration completion, Sentry isolated hub)

No wrapper API changes.