### PR TITLE
chore(deps): bump frontegg-ios-swift to 1.3.17 (FR-26132)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ The Flutter SDK supports Frontegg's **per-tenant sessions** feature through the 
 
 - On **Android**, the plugin and example apps use `com.frontegg.sdk:android:1.3.35`.
 - On **iOS**, the plugin depends on `FronteggSwift`:
-  - **Flutter 3.41+** (SPM): `1.3.11` from GitHub. Run `flutter config --enable-swift-package-manager`, then `flutter pub get` and build.
+  - **Flutter 3.41+** (SPM): `1.3.17` from GitHub. Run `flutter config --enable-swift-package-manager`, then `flutter pub get` and build.
   - Note: CocoaPods fallback is no longer supported for `FronteggSwift`.
   - SPM integration requires **Xcode 15+**.
 

--- a/ios/frontegg_flutter/Package.swift
+++ b/ios/frontegg_flutter/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
-        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.12"),
+        .package(url: "https://github.com/frontegg/frontegg-ios-swift.git", exact: "1.3.17"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Bumps `frontegg-ios-swift` to **1.3.17**, which fixes [FR-26132](https://frontegg.atlassian.net/browse/FR-26132) — embedded Google login failing with `Failed to get extract code from hostedLoginCallback url` despite the provider authenticating successfully. Verified end-to-end by the reporting customer on the fix branch.

`Package.swift` pins the iOS SDK with `exact:`, so consumers cannot bump it themselves — a plugin release is the only route. v1.0.51 still ships iOS 1.3.12, so no released Flutter version has the fix today.

Also picked up between 1.3.12 and 1.3.17: the App-Link OAuth callback no longer being treated as a magic link, which dropped the PKCE verifier and caused ER-00001 under useAssetLinks, plus better social-callback diagnostics.

Version 1.3.17 is confirmed published, so the exact pin resolves. Android stays at 1.3.36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FR-26132]: https://frontegg.atlassian.net/browse/FR-26132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ