### PR TITLE
docs: appId in associated-domains registration is the app identifier, not a domain

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -209,9 +209,9 @@ public class FronteggSwiftAdapter: NSObject {
 }
 ```
 
-4. Register your domain with Frontegg:
+4. Register your app with Frontegg:
 
-**NOTE**: Make youre you have
+**NOTE**: Make sure you have
 a [vendor token to access Frontegg APIs](https://docs.frontegg.com/reference/getting-started-with-your-api).
 
 a. Open your terminal or API tool (such as Postman or cURL).
@@ -221,12 +221,14 @@ c. Include the following JSON payload in the request body:
 
 ```json
 {
-  "appId": "{{ASSOCIATED_DOMAIN}}"
+  "appId": "{{TEAM_ID}}.{{BUNDLE_ID}}"
 }
 ```
 
-d. Replace `{{ASSOCIATED_DOMAIN}}` with the actual associated domain you want to use for the iOS
-app.
+d. Replace `{{TEAM_ID}}` with your Apple Team ID and `{{BUNDLE_ID}}` with your app's bundle
+identifier — for example, `ABCDE12345.com.example.app`. `appId` is your app's identifier, **not** a
+domain: the API accepts any string without validation, but a domain registered here produces an
+`apple-app-site-association` entry that iOS silently ignores.
 e. Repeat this step for each Frontegg environment where you want to support URL-based app opening.
 
 #### `For Swift:`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,9 +21,13 @@ Request body:
 
 ```json
 {
-  "appId": "{{ASSOCIATED_DOMAIN}}"
+  "appId": "{{TEAM_ID}}.{{BUNDLE_ID}}"
 }
 ```
+
+Replace `{{TEAM_ID}}` with your Apple Team ID and `{{BUNDLE_ID}}` with your app's bundle identifier — for example, `ABCDE12345.com.example.app`. You can find your Team ID in the [Apple Developer portal](https://developer.apple.com/account) under **Membership details**, or in Xcode under **Signing & Capabilities**.
+
+> **Warning:** `appId` is your app's identifier, **not** a domain. The API accepts any string without validation, but a domain registered here produces an `apple-app-site-association` entry that iOS silently ignores — Universal Links and passkeys will not work, with no error anywhere. (The *domain* belongs in the associated domains capability in the next step; the two values are different things.)
 
 3. Add associated domains capability to your iOS app:
 


### PR DESCRIPTION
Companion to frontegg/frontegg-ios-swift#314 — full analysis and live-environment evidence there.

Both `docs/setup.md` and `docs/getting-started.md` told readers to register a **domain** in the `appId` field of `POST /vendors/resources/associated-domains/v1/ios`. The field is the Apple app identifier (`{teamId}.{bundleId}`) as published in the `apple-app-site-association` file. The API accepts any string without validation, so a domain registered there produces an AASA entry iOS silently ignores — Universal Links and passkeys fail with no error anywhere.

Corrected the payload to `{{TEAM_ID}}.{{BUNDLE_ID}}` with a concrete example, where to find the Team ID, and a warning about the silent failure. The associated-domains capability step keeps the domain — that value really is a domain; the two being conflated is how this went wrong.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)